### PR TITLE
feat: msw추가(create)

### DIFF
--- a/src/app/create/page.tsx
+++ b/src/app/create/page.tsx
@@ -2,6 +2,8 @@
 
 import { useCallback, useEffect, useRef, useState } from "react";
 
+import { useRouter } from "next/navigation";
+
 import { getKeywordList } from "@/app/_common/api/keywordListApi";
 import Button from "@/app/_common/components/Button";
 import Footer from "@/app/_common/Footer";
@@ -81,6 +83,7 @@ export interface FormData {
 }
 
 export default function Page() {
+  const router = useRouter();
   const [formData, setFormData] = useState<FormData>({
     link: "",
     title: "",
@@ -115,6 +118,7 @@ export default function Page() {
 
     fetchKeywords();
   }, []);
+
   const handleSubmit = async () => {
     // 필수값 체크
     if (!formData.link) {
@@ -133,8 +137,10 @@ export default function Page() {
       });
 
       if (response.ok) {
-        alert("플레이리스트가 저장되었습니다!");
-        // 필요하다면 페이지 이동 또는 form 초기화
+        // /detail/id 로 이동
+        const { data: newId } = await response.json();
+
+        router.push(`/detail/${newId}`);
       } else {
         alert("저장에 실패했습니다.");
       }
@@ -177,6 +183,7 @@ export default function Page() {
           title="# 키워드 선택"
           keywords={keywords}
           showAddButton={true}
+          onSelectionChange={(selected) => updateFormData("selectedKeywords", selected)}
           // onKeywordClick={(keyword) => console.log(keyword)}
           // onAddClick={() => console.log("Add clicked")}
         />

--- a/src/app/create/page.tsx
+++ b/src/app/create/page.tsx
@@ -73,7 +73,7 @@ function useHeaderAnimation(scrollRef: React.RefObject<HTMLDivElement | null>) {
   return { style, scrolling } as const;
 }
 
-interface FormData {
+export interface FormData {
   link: string;
   title: string;
   desc: string;
@@ -115,6 +115,33 @@ export default function Page() {
 
     fetchKeywords();
   }, []);
+  const handleSubmit = async () => {
+    // 필수값 체크
+    if (!formData.link) {
+      alert("링크를 입력해주세요.");
+
+      return;
+    }
+
+    try {
+      const response = await fetch("/api/createPlaylist", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(formData),
+      });
+
+      if (response.ok) {
+        alert("플레이리스트가 저장되었습니다!");
+        // 필요하다면 페이지 이동 또는 form 초기화
+      } else {
+        alert("저장에 실패했습니다.");
+      }
+    } catch (error) {
+      alert(`네트워크 오류가 발생했습니다. ${error}`);
+    }
+  };
 
   return (
     <Layout className="relative flex h-screen flex-col overflow-hidden px-[56px] pt-[50px] pb-[89px]">
@@ -154,7 +181,12 @@ export default function Page() {
           // onAddClick={() => console.log("Add clicked")}
         />
         <ImageSelector title={"이미지 선택"} />
-        <Button type={"submit"}>만들기</Button>
+        <Button
+          type={"submit"}
+          onClick={handleSubmit}
+        >
+          만들기
+        </Button>
       </div>
 
       <Footer selectedIndex={0} />

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -5,9 +5,12 @@ import { KeywordList } from "./sample/Keyword";
 import { DetailList, PlayListSample } from "./sample/Playlist";
 import { Playlists, popularPlayList } from "./sample/Playlists";
 
+import { Keyword } from "@/app/_common/types/keyword";
+
 import type { NewUser, User } from "./sample/User";
 import type { FormData } from "@/app/create/page";
 import type playlist from "@/app/playlists/types/playlist";
+import type { PlayList as PlaylistDetailType } from "@/mocks/sample/Playlist";
 
 const members: User[] = [
   {
@@ -37,6 +40,8 @@ const members: User[] = [
 ];
 
 const mockPlaylists: playlist[] = [...Playlists];
+
+const mockPlaylistsDescription: PlaylistDetailType[] = [...PlayListSample];
 
 export const handlers = [
   // 사용자 목록을 가져오는 API
@@ -71,11 +76,11 @@ export const handlers = [
     if (id) {
       const targetId = parseInt(id);
       // id가 있으면 해당 플레이리스트만 반환
-      let filteredData = PlayListSample.filter((playlist) => playlist.id === targetId);
+      let filteredData = mockPlaylistsDescription.filter((playlist) => playlist.id === targetId);
 
       // 해당 ID가 없으면 id=1인 데이터를 반환(테스트용 실제데이터 사용하면 지워야함)
       if (filteredData.length === 0) {
-        filteredData = PlayListSample.filter((playlist) => playlist.id === 1);
+        filteredData = mockPlaylistsDescription.filter((playlist) => playlist.id === 1);
       }
 
       return HttpResponse.json({
@@ -87,7 +92,7 @@ export const handlers = [
     // id가 없으면 전체 반환
     return HttpResponse.json({
       status: 200,
-      data: PlayListSample,
+      data: mockPlaylistsDescription,
     });
   }),
 
@@ -150,20 +155,37 @@ export const handlers = [
   http.post("/api/createPlaylist", async ({ request }) => {
     const newPlaylist = (await request.json()) as FormData;
 
+    const newId = mockPlaylists.length + 1;
+
     // id 자동 증가 및 createdAt 추가
     const createdPlaylist = {
-      id: Math.floor(Math.random() * 1000), // 1000미만의 임의의 숫자
+      id: newId, // 새로운 ID 할당
       title: newPlaylist.title,
       nickName: "mock채은",
       digCount: "0",
       shareCount: "0",
+      coverImageUrl: "https://image.bugsm.co.kr/album/images/500/40441/4044167.jpg",
     };
 
     mockPlaylists.push(createdPlaylist);
 
+    const createdPlaylistDescription = {
+      id: newId,
+      title: newPlaylist.title,
+      bio: newPlaylist.desc,
+      tags: newPlaylist.selectedKeywords.map((keyword: Keyword) => keyword.label),
+      coverURL: "https://image.bugsm.co.kr/album/images/500/40441/4044167.jpg",
+      like: { isLiked: false, cnt: 0 },
+      comment: 0,
+      share: 0,
+      digging: 0,
+    };
+
+    mockPlaylistsDescription.push(createdPlaylistDescription);
+
     return HttpResponse.json({
       status: 201,
-      data: newPlaylist,
+      data: newId,
     });
   }),
 ];

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -6,6 +6,8 @@ import { DetailList, PlayListSample } from "./sample/Playlist";
 import { Playlists, popularPlayList } from "./sample/Playlists";
 
 import type { NewUser, User } from "./sample/User";
+import type { FormData } from "@/app/create/page";
+import type playlist from "@/app/playlists/types/playlist";
 
 const members: User[] = [
   {
@@ -33,6 +35,8 @@ const members: User[] = [
       "https://cdnimg.melon.co.kr/cm2/artistcrop/images/008/95/389/895389_20250502185925_500.jpg?YUV444/melon/resize/416",
   },
 ];
+
+const mockPlaylists: playlist[] = [...Playlists];
 
 export const handlers = [
   // 사용자 목록을 가져오는 API
@@ -138,7 +142,28 @@ export const handlers = [
   http.get("/api/getMyPlaylists", () => {
     return HttpResponse.json({
       status: 200,
-      data: Playlists,
+      data: mockPlaylists,
+    });
+  }),
+
+  // 플레이리스트 생성 API 추가 - detail 제외
+  http.post("/api/createPlaylist", async ({ request }) => {
+    const newPlaylist = (await request.json()) as FormData;
+
+    // id 자동 증가 및 createdAt 추가
+    const createdPlaylist = {
+      id: Math.floor(Math.random() * 1000), // 1000미만의 임의의 숫자
+      title: newPlaylist.title,
+      nickName: "mock채은",
+      digCount: "0",
+      shareCount: "0",
+    };
+
+    mockPlaylists.push(createdPlaylist);
+
+    return HttpResponse.json({
+      status: 201,
+      data: newPlaylist,
     });
   }),
 ];

--- a/src/mocks/sample/Playlist.ts
+++ b/src/mocks/sample/Playlist.ts
@@ -25,10 +25,9 @@ export const PlayListSample: PlayList[] = [
   },
   {
     id: 2,
-    title:
-      "규리누나는 이게 바뀌었다는걸 알고 있을까? 아 깃을 보면 알겠구나 알면 어쩔건데 ㅋ 개의치 않고 나는 올릴것이다 그래도 1번은 양보했다",
-    bio: "이것은 규리누나를 약올리기 위한 에스파 플리다",
-    tags: ["데이식스", "보단", "에스파"],
+    title: "don't you know I'm a savage? 걸그룹은 쇠맛이지!",
+    bio: "I'm a rich man, I'm a rich man!",
+    tags: ["쇠맛", "hot", "에스파"],
     coverURL: "https://i.ytimg.com/vi/jWQx2f-CErU/hq720.jpg",
     like: { isLiked: false, cnt: 100 },
     comment: 44,


### PR DESCRIPTION
## 요약
- /create msw 추가
- 추가 완료 후 detail/[id]로 리다이렉트
- 새로 저장한 플레이리스트를 홈에서도 확인

https://github.com/user-attachments/assets/9879ff01-b2e6-4e5c-9306-9d7f966d7bdd



<br><br>

## 작업 내용
- 키워드를 선택 시 form에 추가하고, 저장버튼 클릭 시 함께 넘어가도록 처리
<br><br>

## 참고 사항
- 앨범아트 url, 유저 정보(닉네임)은 하드코딩한 값 쓰도록 함
  - 앨범아트는 서버에서 처리 후 저장경로를 저장해야 함
  - 닉네임 또한 서버에서 유저정보로 처리하는 것이 맞다고 판단 
 - 첨부한 url의 음악 목록도 규리 목데이터 갖다쓰도록 함 
<br><br>

## 관련 이슈

- Close #74 

<br><br>
